### PR TITLE
fix(user): enforce USER_ROLE by default in createUser API

### DIFF
--- a/controllers/users.controller.js
+++ b/controllers/users.controller.js
@@ -69,9 +69,10 @@ const getUserByID = async (req = request, res = response) => {
 const addUser = async (req = request, res = response) => {
 
     //Obtengo el body del request
-    const { userName, email, password, role } = req.body;
+    const { userName, email, password } = req.body;
     //Creo una instancia de mi user schema y le paso los parametros obligatorios
-    const user = new UserModel({ userName, email, password, role });
+    //El rol se asigna por defecto en el schema
+    const user = new UserModel({ userName, email, password });
 
     //Encriptar password
     const salt = bcryptjs.genSaltSync();

--- a/routes/userRoutes.js
+++ b/routes/userRoutes.js
@@ -43,9 +43,6 @@ router.post('/', [
     check('email', 'El correo no es valido').isEmail(),
     check('password','El password es obligatorio').notEmpty(),
     check('password','El password debe tener mas de 4 caracteres').isLength({min: 5}),
-    check('role','El rol es obligatorio').notEmpty(),
-    check('role').custom( (role) => validRole(role) ),//Es lo mismo que abajo debido a que el parametro se llama igual
-    // check('role').custom( validRole ),
     check('email').custom(validExistedEmail),
     validateFields
 ], addUser)


### PR DESCRIPTION
# 🔧 Fix: Default USER_ROLE Assignment in Create User API

## 🎯 Objective
This PR fixes a bug in the **Create User API** where clients could potentially assign themselves elevated roles (e.g., `ADMIN_ROLE`). Now, every new user created via this endpoint will automatically be assigned **`USER_ROLE`**, regardless of what is sent in the request body.

---

## 🛠 Changes Implemented

1. **Backend - User Controller**
   - Removed reading of `role` from the request body in `createUser`.
   - Automatically assigns `USER_ROLE` to new users.

2. **User Routes**
   - Removed `check('role', 'El rol es obligatorio')` middleware since the role is no longer required from the client.
   - Kept `validRole` validation for other use cases (like admin endpoints).

3. **User Model**
   - No changes needed. `role` field still has:
     ```js
     role: {
       type: String,
       required: true,
       enum: ['USER_ROLE','ADMIN_ROLE','TEST_ROLE'],
       default: 'USER_ROLE'
     }
     ```
   - Default ensures new users are created with `USER_ROLE`.

---

## 🔒 Security / Bug Fix
- Prevents clients from assigning themselves **elevated roles**.
- Ensures that the **default role** is always safe for new registrations.

---

## ✅ Testing
- Verified new users are created with `USER_ROLE`.
- Attempted to send `ADMIN_ROLE` in request → ignored, user is still `USER_ROLE`.
- Existing UI flows remain **compatible**.

---

## 📝 Notes
- Any role validation for admin endpoints or other features remains unaffected.
- This PR focuses solely on **safe user creation** for general registration.
