### PR TITLE
✨ Feature: Scroll infinito en catálogo de animes

### DIFF
--- a/routes/animeRoutes.js
+++ b/routes/animeRoutes.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import { check } from 'express-validator';
+import { check, query } from 'express-validator';
 //Middlewares
 import { JWTValidation } from '../middlewares/validate-jwt.js';
 import validateFields from '../middlewares/validate-fields.js';
@@ -20,7 +20,10 @@ const router = express.Router();
 //Get animes
 
 router.get('/', [
-    JWTValidation
+    JWTValidation,
+    query('offset', 'El offset debe ser un número positivo').optional().isInt({ min: 0 }),
+    query('limit', 'El limit debe ser un número mayor a 1 y menor o igual a 50').optional().isInt({ min: 1, max: 50 }),
+    validateFields
 ], getAllAnimes);
 
 
@@ -52,8 +55,8 @@ router.post('/', [
     check('episodes', 'El número de episodios debe ser un número')
         .optional()
         .isInt({ min: 1 })
-        .custom(value => {
-            if (value && value !== 'serie') {
+        .custom((value, {req}) => {
+            if (value && req.body.type !== 'serie') {
                 throw new Error('El número de episodios solo es válido para series');
             }
             return true;
@@ -62,8 +65,8 @@ router.post('/', [
     check('seasons', 'El número de temporadas debe ser un número')
         .optional()
         .isInt({ min: 1 })
-        .custom(value => {
-            if (value && value !== 'serie') {
+        .custom((value, {req}) => {
+            if (value && req.body.type !== 'serie') {
                 throw new Error('El número de temporadas solo es válido para series');
             }
             return true;
@@ -72,8 +75,8 @@ router.post('/', [
     check('duration', 'La duración debe ser un número')
         .optional()
         .isInt({ min: 1 })
-        .custom(value => {
-            if (value && value !== 'pelicula') {
+        .custom((value, {req}) => {
+            if (value && req.body.type !== 'pelicula') {
                 throw new Error('La duración solo es válida para películas');
             }
             return true;


### PR DESCRIPTION
Este PR agrega la funcionalidad de scroll infinito para la obtención de animes en el catálogo.
Además, se corrigieron validaciones en el endpoint de creación de animes.

### 🛠️ Cambios realizados

- Controller (getAnimes)
  - Implementación de paginación con offset y limit.
  - Se retornan únicamente las propiedades necesarias:
    - imageURL
    - title
    - description
    - type
    - studio
- Ordenamiento por title y createdAt.
- Respuesta estructurada con:
  - total → cantidad total de animes en la base de datos.
  - count → cantidad de animes retornados en la consulta.
  - animes → listado de animes paginados.

**Routes GET (/api/animes)**

🛡️ Validaciones aplicadas
🔹 Query Params (GET /api/animes)

1. offset: debe ser un número entero positivo (mínimo 0).
2. limit: debe ser un número entero mayor a 1 y menor o igual a 50.



### ✅ Ejemplo de uso

**GET /api/animes?offset=0&limit=10**

Response (200):
```json
{
  "total": 125,
  "count": 10,
  "animes": [
    {
      "imageURL": "https://example.com/anime1.jpg",
      "title": "Naruto",
      "description": "Historia de un ninja...",
      "type": "Shonen",
      "studio": "Pierrot"
    },
    ...
  ]
}

```


### Corrección en createAnime

**Validación ajustada en los campos:**

- episodes
- seasons
- duration