### PR TITLE
Create GetAllUsers API and add pagination with limit and offset

### DIFF
--- a/controllers/users.controller.js
+++ b/controllers/users.controller.js
@@ -33,6 +33,7 @@ const getAllUsers = async (req = request, res = response) => {
             // Seleccionar y renombrar campos
             {
                 $project: {
+                    _id: 0,
                     uid: "$_id",
                     userName: 1,
                     email: 1,

--- a/routes/userRoutes.js
+++ b/routes/userRoutes.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import { check } from 'express-validator';
+import { check, query } from 'express-validator';
 //Middlewares
 import validateFields from '../middlewares/validate-fields.js';
 import { JWTValidation } from '../middlewares/validate-jwt.js';
@@ -24,8 +24,11 @@ const router = express.Router();
 //Get users
 router.get('/', [
     JWTValidation,
-    validateAdminRole
-    // validateRole('ADMIN_ROLE')
+    query('offset', 'El offset debe ser un número positivo').optional().isInt({ min: 0 }),
+    query('limit', 'El limit debe ser un número mayor a 1 y menor o igual a 100').optional().isInt({ min: 1, max: 100 }),
+    validateFields,
+    validateAdminRole,
+    validateRole('ADMIN_ROLE')
 ], getAllUsers)
 
 //Get user by ID


### PR DESCRIPTION
Se implementa paginación en el endpoint GET /api/users para permitir a los clientes obtener resultados en bloques definidos.
Esto facilita el manejo de grandes volúmenes de datos y mejora la escalabilidad del sistema.

# ✅ Cambios principales

- Se agregan parámetros de query offset y limit con valores por defecto (offset=0, limit=25).
- Se valida que:
  - offset ≥ 0
  - 1 ≤ limit ≤ 100
- Se actualiza el aggregate en getAllUsers para incluir:
  - $skip y $limit en función de la paginación.
  - Proyección de campos relevantes.
  - Cálculo de totalAnimes por usuario.
- Respuesta actualizada para incluir paginación.

# 🧪 Ejemplos de request

```http
# Paginación por defecto (25 usuarios desde el inicio)
GET /api/users

# Obtener 10 usuarios empezando desde el usuario 30
GET /api/users?offset=30&limit=10

# Límite máximo permitido (100 usuarios)
GET /api/users?limit=100

```

# 📂 Respuesta

```
{
            "userName": "fernalgas langas",
            "email": "ferchoso@gmail.com",
            "role": "USER_ROLE",
            "state": true,
            "userOrigin": "2025-08-10T02:11:20.276Z",
            "totalAnimes": 0,
            "uid": "6897ffc8b636fbfb2a53e93e"
        }
```

🚀 Beneficios
- Mejora el rendimiento en consultas de usuarios.
- Permite al QA probar distintos escenarios de paginación fácilmente.
- Escalable para grandes volúmenes de datos.