### PR TITLE
FIX: Ajuste en getUserByID para que usuarios puedan ver perfiles públicos de otros usuarios sin exponer informacion privada

### DIFF
--- a/controllers/users.controller.js
+++ b/controllers/users.controller.js
@@ -81,41 +81,37 @@ const getUserByID = async (req = request, res = response) => {
             })
         }
 
+        //Convertir a objeto para manipular
+        const userObj = user.toObject();
+
         //Get user Anime Collection
         const userAnimeCollection = await UserCollectionModel.findOne({ user: userID });
 
         //Count total animes in user collection
         const TotalAnimes = userAnimeCollection ? userAnimeCollection.animes.length : 0;
 
+        //Base response object
+        let userResponse = {
+            userName: userObj.userName,
+            email: userObj.email,
+            img: userObj.img || null,
+            TotalAnimes
+        }
+
         const { role, id } = req.userFromToken;
         //If user is ADMIN_ROLE return all user info
         if (role === "ADMIN_ROLE") {
-            return res.status(200).json({
-                user,
+            userResponse = {
+                ...userObj,
                 TotalAnimes
-            });
+            }
         }
 
-        //// If the requester is a USER_ROLE, only allow fetching their own profile with limited info
-        if (role === "USER_ROLE" && id === userID) {
-            const { userName, email, img } = user.toObject();
-
-            return res.status(200).json({
-                user: {
-                    userName,
-                    email,
-                    img: img || null,
-                    TotalAnimes
-                }
-            })
-        }
-        else {
-            return res.status(403).json({
-                ok: false,
-                msg: 'Usuario no autorizado para ver este perfil'
-            })
-        }
-
+        //Return response
+        return res.status(200).json({
+            ok: true,
+            user: userResponse
+        });
 
     } catch (error) {
         console.error(error);


### PR DESCRIPTION

## 🚀 Descripción
Se realizó un ajuste en el endpoint `getUserByID` para mejorar la lógica de visualización de perfiles:

- Ahora **usuarios con rol `USER_ROLE` pueden consultar perfiles de otros usuarios**, mostrando únicamente información pública:
  - `userName`
  - `profileImage`
  - `totalAnimes`
  - `email`
- Los usuarios siguen pudiendo **ver su propio perfil completo**, incluyendo:
  - `userName`
  - `email`
  - `profileImage`
  - `totalAnimes`
- Se omitió la devolución del `role` en perfiles públicos para mantener la privacidad y simplificar la información.

## ✅ Cambios principales
- Modificación del controlador `getUserByID`.
- Refactorización de la lógica de retorno para evitar duplicaciones.
- Validaciones ajustadas según el rol del usuario y si consulta su propio perfil o el de otro.
